### PR TITLE
feat: use `ajv-formats` when validating against schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2118,6 +2118,14 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.5.1.tgz",
+      "integrity": "sha512-s1RBVF4HZd2UjGkb6t6uWoXjf6o7j7dXPQIL7vprcIT/67bTD6+5ocsU0UKShS2qWxueGDWuGfKHfOxHWrlTQg==",
+      "requires": {
+        "ajv": "^7.0.0"
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@octokit/webhooks": "^7.21.0",
     "@slack/webhook": "^5.0.4",
     "ajv": "^7.0.3",
+    "ajv-formats": "^1.5.1",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/src/github/EventValidator.ts
+++ b/src/github/EventValidator.ts
@@ -1,4 +1,5 @@
 import Ajv, { DefinedError, ErrorObject, ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
 import { strict as assert } from 'assert';
 import fs from 'fs';
 import { JSONSchema7 } from 'json-schema';
@@ -13,7 +14,7 @@ export class EventValidator<
   TEventName extends GithubEvent['name'],
   TEvent extends Extract<GithubEvent, { name: TEventName }>
 > {
-  private readonly _ajv = new Ajv();
+  private readonly _ajv = addFormats(new Ajv({}), {});
   private readonly _validator: ValidateFunction<TEvent>;
   private readonly _eventName: string;
   private readonly _logger: Logger;

--- a/test/src/github/EventValidator.spec.ts
+++ b/test/src/github/EventValidator.spec.ts
@@ -8,6 +8,7 @@ import { EventValidator, GithubEvent, Logger } from '../../../src/github';
 import pingEvent from '../../fixtures/ping.json';
 
 jest.mock('ajv');
+jest.mock('ajv-formats', () => (ajv: Ajv) => ajv);
 
 const mockedAjv = mocked(Ajv, true);
 const schemaValidatorMock = (jest.fn() as unknown) as jest.MockedFunction<ValidateFunction>;
@@ -31,6 +32,9 @@ const oneOfError = (): OneOfError => ({
 
 describe('EventValidator', () => {
   beforeEach(() => {
+    // manually reset the `errors` array
+    delete schemaValidatorMock.errors;
+
     mockedAjv.prototype.compile.mockReturnValue(schemaValidatorMock);
     vol.fromNestedJSON({ common: {}, ping: {} }, 'src/schemas');
   });


### PR DESCRIPTION
Closes #25 