### PR TITLE
fix: remove optional value for `logger` parameter in `EventValidator`

### DIFF
--- a/src/github/EventValidator.ts
+++ b/src/github/EventValidator.ts
@@ -20,12 +20,12 @@ export class EventValidator<
 
   public static validate<TStaticEvent extends GithubEvent>(
     event: TStaticEvent,
-    logger: Logger = console
+    logger: Logger
   ): ErrorObject[] {
     return new this(event.name, logger).validate(event);
   }
 
-  public constructor(eventName: TEventName, logger: Logger = console) {
+  public constructor(eventName: TEventName, logger: Logger) {
     this._eventName = eventName;
     this._logger = logger;
 

--- a/test/src/github/EventValidator.spec.ts
+++ b/test/src/github/EventValidator.spec.ts
@@ -96,13 +96,11 @@ describe('EventValidator', () => {
       );
     });
 
-    describe('when given a custom logger', () => {
-      it('is used for logging', () => {
-        // eslint-disable-next-line no-new
-        new EventValidator('ping', mockLogger);
+    it('logs to the given logger', () => {
+      // eslint-disable-next-line no-new
+      new EventValidator('ping', mockLogger);
 
-        expect(mockLogger.info).toHaveBeenCalledWith(expect.any(String));
-      });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.any(String));
     });
   });
 


### PR DESCRIPTION
We always pass in a value for this parameter, and removing it increases our coverage.