### PR TITLE
ci: use personal github access token for `update` workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,7 +25,7 @@ jobs:
       - name: create pull request
         uses: gr2m/create-or-update-pull-request-action@v1
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
         with:
           title: "\U0001F6A7 \U0001F916\U0001F4EF Webhooks changed"
           body: >


### PR DESCRIPTION
Fixes #40 