### PR TITLE
fix: allow any schema to use `oneOf` at it's root

### DIFF
--- a/scripts/copy-schemas.ts
+++ b/scripts/copy-schemas.ts
@@ -29,7 +29,7 @@ const getFolderAndSchemaName = (
 Object.entries(
   webhooksSchema.definitions as Record<string, JSONSchema7>
 ).forEach(([key, definition]) => {
-  if (definition.oneOf) {
+  if (key.includes('_event')) {
     return;
   }
 

--- a/scripts/copy-schemas.ts
+++ b/scripts/copy-schemas.ts
@@ -27,7 +27,8 @@ const getFolderAndSchemaName = (
 };
 
 Object.entries(
-  webhooksSchema.definitions as Record<string, JSONSchema7>
+  // Temporary fix, the types have regressed against `@octokit/webhooks-schema@3.75.2`
+  (webhooksSchema.definitions as unknown) as Record<string, JSONSchema7>
 ).forEach(([key, definition]) => {
   if (key.includes('_event')) {
     return;


### PR DESCRIPTION
Instead of checking if the `oneOf` property exists on a schema at the root, check that it isn't a webhook event `oneOf`since schemas that contain `$event` are singular event schemas, while those that contain `_event` are for multiple event schemas.


Examples: 
* https://github.com/octokit/webhooks/commit/b92da59849cfebc31f746d0cf0cadb3af25525fc#diff-29bc7a5353c6413651e02720bad379a8f32fa46fdf565b811cfd5e6181800a0a
* https://github.com/octokit/webhooks/commit/403374ebb2cd60656014784e6a1abed73f464180#diff-918f97c1df309e374e4858365fb7d877f6321f2bbabfbedf93fd1eb993ef9f33

This PR unblocks updates of `@octokit/webhooks-schemas`

There will also be some type issues when upgrading, which I haven't seem to have found the way to fix. I've cast it to unknown first